### PR TITLE
Fix indentation inconsistency in python scripts + typos in readme

### DIFF
--- a/object detection/README.md
+++ b/object detection/README.md
@@ -1,5 +1,5 @@
 # ZED SDK - Object Detection
 
- - **Birds eye viewer**: Deteted objects are displayed in a **3D** view with the current point cloud.
+ - **Birds eye viewer**: Detected objects are displayed in a **3D** view with the current point cloud.
  - **Image viewer**: Detected objects are displayed in a **2D** view with the current image.
  - **Custom detector**: Sample with external detectors to use the DETECTION_MODEL::CUSTOM_BOX_OBJECTS mode

--- a/object detection/birds eye viewer/python/ogl_viewer/viewer.py
+++ b/object detection/birds eye viewer/python/ogl_viewer/viewer.py
@@ -213,7 +213,7 @@ class Simple3DObject:
         self.indices.append(len(self.indices))
 
     def add_vertical_faces(self, _pts, _clr):
-    	# For each face, we need to add 4 quads (the first 2 indexes are always the top points of the quad)
+        # For each face, we need to add 4 quads (the first 2 indexes are always the top points of the quad)
         quads = [[0, 3, 7, 4]       # Front face
                 , [3, 2, 6, 7]      # Right face
                 , [2, 1, 5, 6]      # Back face
@@ -518,13 +518,13 @@ class GLViewer:
         
     def create_bbox_rendering(self, _bbox, _bbox_clr):
         # First create top and bottom full edges
-	    self.BBox_edges.add_full_edges(_bbox, _bbox_clr)
-	    # Add faded vertical edges
-	    self.BBox_edges.add_vertical_edges(_bbox, _bbox_clr)
-	    # Add faces
-	    self.BBox_faces.add_vertical_faces(_bbox, _bbox_clr)
-	    # Add top face
-	    self.BBox_faces.add_top_face(_bbox, _bbox_clr)
+        self.BBox_edges.add_full_edges(_bbox, _bbox_clr)
+        # Add faded vertical edges
+        self.BBox_edges.add_vertical_edges(_bbox, _bbox_clr)
+        # Add faces
+        self.BBox_faces.add_vertical_faces(_bbox, _bbox_clr)
+        # Add top face
+        self.BBox_faces.add_top_face(_bbox, _bbox_clr)
 
     def idle(self):
         if self.available:

--- a/object detection/image viewer/python/ogl_viewer/viewer.py
+++ b/object detection/image viewer/python/ogl_viewer/viewer.py
@@ -37,16 +37,16 @@ M_PI = 3.1415926
 GRID_SIZE = 15.0
 
 CLASS_COLORS = np.array([
-	[44, 117, 255]          # People
-	, [255, 0, 255]         # Vehicle
-	, [0, 0, 255]
+    [44, 117, 255]          # People
+    , [255, 0, 255]         # Vehicle
+    , [0, 0, 255]
     , [0, 255, 255]
     , [0, 255, 0]
     , [255, 255, 255]]
     , np.float32)
 
 ID_COLORS = np.array([
-	[0.231, 0.909, 0.69]
+    [0.231, 0.909, 0.69]
     , [0.098, 0.686, 0.816]
     , [0.412, 0.4, 0.804]
     , [1, 0.725, 0]
@@ -253,7 +253,7 @@ class Simple3DObject:
         self.indices.append(len(self.indices))
 
     def add_vertical_faces(self, _pts, _clr):
-    	# For each face, we need to add 4 quads (the first 2 indexes are always the top points of the quad)
+        # For each face, we need to add 4 quads (the first 2 indexes are always the top points of the quad)
         quads = [[0, 3, 7, 4]       # Front face
                 , [3, 2, 6, 7]      # Right face
                 , [2, 1, 5, 6]      # Back face
@@ -396,8 +396,8 @@ IMAGE_VERTEX_SHADER = """
 layout(location = 0) in vec3 vert;
 out vec2 UV;
 void main() {
-   UV = (vert.xy+vec2(1,1))/2;
-	gl_Position = vec4(vert, 1);
+    UV = (vert.xy+vec2(1,1))/2;
+    gl_Position = vec4(vert, 1);
 }
 """
 
@@ -618,13 +618,13 @@ class GLViewer:
 
     def create_bbox_rendering(self, _bbox, _bbox_clr):
         # First create top and bottom full edges
-	    self.BBox_edges.add_full_edges(_bbox, _bbox_clr)
-	    # Add faded vertical edges
-	    self.BBox_edges.add_vertical_edges(_bbox, _bbox_clr)
-	    # Add faces
-	    self.BBox_faces.add_vertical_faces(_bbox, _bbox_clr)
-	    # Add top face
-	    self.BBox_faces.add_top_face(_bbox, _bbox_clr)
+        self.BBox_edges.add_full_edges(_bbox, _bbox_clr)
+        # Add faded vertical edges
+        self.BBox_edges.add_vertical_edges(_bbox, _bbox_clr)
+        # Add faces
+        self.BBox_faces.add_vertical_faces(_bbox, _bbox_clr)
+        # Add top face
+        self.BBox_faces.add_top_face(_bbox, _bbox_clr)
 
     def create_id_rendering(self, _center, _clr, _id):
         tmp = ObjectClassName()

--- a/tutorials/tutorial 1 - hello ZED/python/README.md
+++ b/tutorials/tutorial 1 - hello ZED/python/README.md
@@ -73,7 +73,7 @@ In the console window, you should now see the serial number of the camera (also 
 
 To close the camera properly, use zed.close() and exit the program.
 
-```
+```python
 # Close the camera
 zed.close()
 return 0

--- a/tutorials/tutorial 2 - image capture/python/README.md
+++ b/tutorials/tutorial 2 - image capture/python/README.md
@@ -79,7 +79,7 @@ while (i < 50) :
 
 Now that we have captured 50 images, we can close the camera and exit the program.
 
-```
+```python
 # Close the camera
 zed.close()
 return 0

--- a/tutorials/tutorial 3 - depth sensing/python/README.md
+++ b/tutorials/tutorial 3 - depth sensing/python/README.md
@@ -40,20 +40,18 @@ Retrieving the depth map is as simple as retrieving an image:
 * We create a Mat to store the depth map.
 * We call retrieve_measure() to get the depth map.
 
-```
+```python
 # Capture 50 images and depth, then stop
 i = 0
 image = sl.Mat()
 depth = sl.Mat()
-while (i < 50) :
+while i < 50 :
     # Grab an image
-    if (zed.grab() == sl.ERROR_CODE.SUCCESS) :
+    if zed.grab() == sl.ERROR_CODE.SUCCESS :
         # A new image is available if grab() returns SUCCESS
         zed.retrieve_image(image, sl.VIEW.LEFT) # Get the left image
         zed.retrieve_measure(depth, sl.MEASURE.DEPTH) # Retrieve depth Mat. Depth is aligned on the left image
         i = i + 1
-    }
-}
 ```
 
 
@@ -73,7 +71,7 @@ printf("Distance to Camera at (", x, y, "): ", distance, "mm")
 
 Once 50 frames have been grabbed, we close the camera.
 
-```
+```python
 # Close the camera
 zed.close()
 ```


### PR DESCRIPTION
Fix some indentation inconsistency in python scrips which prevent them to run properly, and a few typos and syntax errors in code samples and some Readme