### PR TITLE
no module found scale_coords from utils.general

### DIFF
--- a/object detection/custom detector/python/pytorch_yolov5/detector.py
+++ b/object detection/custom detector/python/pytorch_yolov5/detector.py
@@ -11,7 +11,7 @@ import torch.backends.cudnn as cudnn
 
 sys.path.insert(0, './yolov5')
 from models.experimental import attempt_load
-from utils.general import check_img_size, non_max_suppression, scale_coords, xyxy2xywh
+from utils.general import check_img_size, non_max_suppression, scale_boxes, xyxy2xywh
 from utils.torch_utils import select_device
 from utils.augmentations import letterbox
 
@@ -71,7 +71,7 @@ def detections_to_custom_box(detections, im, im0):
     output = []
     for i, det in enumerate(detections):
         if len(det):
-            det[:, :4] = scale_coords(im.shape[2:], det[:, :4], im0.shape).round()
+            det[:, :4] = scale_boxes(im.shape[2:], det[:, :4], im0.shape).round()
             gn = torch.tensor(im0.shape)[[1, 0, 1, 0]]  # normalization gain whwh
 
             for *xyxy, conf, cls in reversed(det):


### PR DESCRIPTION
yoloc5/utils.py function name was changed `scale_coords` to `scale_boxes`. It's fix this